### PR TITLE
fix(db): type correctly number and null

### DIFF
--- a/server/dbSchema.ts
+++ b/server/dbSchema.ts
@@ -159,25 +159,25 @@ export const GHG_EMISSIONS_PER_CAPITA_ghg_per_capita_prod = {
 };
 
 export const GHG_EMISSIONS_ghg_full_by_gas_prod = {
-  source: "source",
   group_type: "group_type",
   group_name: "group_name",
   year: "year",
   gas: "gas",
-  ghg: "ghg",
   ghg_unit: "ghg_unit",
   including_lucf: "including_lucf",
+  source: "source",
+  ghg: "ghg",
   __tableName: "GHG_EMISSIONS_ghg_full_by_gas_prod"
 };
 
 export const GHG_EMISSIONS_ghg_full_by_sector_prod = {
-  source: "source",
   group_type: "group_type",
   group_name: "group_name",
   year: "year",
-  sector: "sector",
-  ghg: "ghg",
   ghg_unit: "ghg_unit",
+  sector: "sector",
+  source: "source",
+  ghg: "ghg",
   __tableName: "GHG_EMISSIONS_ghg_full_by_sector_prod"
 };
 


### PR DESCRIPTION
Investigating @tvienne feedback https://data-for-good.slack.com/archives/C05T4LVCYMR/p1719414794986399 it looks like this filter https://github.com/dataforgoodfr/shiftdataportal/blob/199753622a9debc2f594a0d7d561e179bc971ad4/server/resolvers/gHGByGas.ts#L71-L73 is the cause of the issue. This is because csv file with empty values are interpreted as empty string instead of null.