### PR TITLE
fix: fix missing data from electricity graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "heroku-postbuild": "yarn build",
     "start": "node ./server/dist/server.js",
-    "dev": "./node_modules/.bin/concurrently  \"cd server && yarn dev\" \"cd client && PORT=3001 npm run start\"",
+    "dev": "./node_modules/.bin/concurrently  \"cd server && yarn dev\" \"cd client && PORT=3001 yarn dev\"",
     "build": "yarn build-client && yarn build-server",
     "build-client": "cd client && yarn && yarn build",
     "build-server": "cd server && yarn && yarn build",

--- a/server/resolvers/electricity.ts
+++ b/server/resolvers/electricity.ts
@@ -88,7 +88,7 @@ const electricity: ElectricityResolvers = {
       const resRawQuery = db
         .knex(CAPACITY.__tableName)
         .select(CAPACITY.year, CAPACITY.energy_family, CAPACITY.group_type, CAPACITY.group_name)
-        .sum(CAPACITY.power)
+        .sum({ sum: CAPACITY.power})
         .whereIn(CAPACITY.energy_family, capacityEnergyFamilies)
         .andWhereBetween(CAPACITY.year, [yearStart, yearEnd])
         .andWhere(CAPACITY.group_name, groupName)
@@ -293,7 +293,7 @@ const electricity: ElectricityResolvers = {
       const resRawQuery = db
         .knex(CAPACITY.__tableName)
         .select(CAPACITY.year, CAPACITY.group_name)
-        .sum(CAPACITY.power)
+        .sum({ sum: CAPACITY.power})
         .whereIn(CAPACITY.group_name, groupNames)
         .andWhereBetween(CAPACITY.year, [yearStart, yearEnd])
         .groupBy(CAPACITY.year, CAPACITY.group_name)


### PR DESCRIPTION
## Problem
Some electricity graphs were not properly displayed.

## Solution
The graphQL query was sending an array of null values because of the omission of the renaming of some summed columns.