### PR TITLE
fix(server): upgrade better-sqlite3

### DIFF
--- a/server/dbSchema.ts
+++ b/server/dbSchema.ts
@@ -72,13 +72,6 @@ export const CO2_CONSUMPTION_BASED_ACCOUNTING_footprint_vs_territorial_prod = {
   __tableName: "CO2_CONSUMPTION_BASED_ACCOUNTING_footprint_vs_territorial_prod"
 };
 
-export const country_multiselect_groups = {
-  group: "group",
-  country: "country",
-  country_only: "country_only",
-  __tableName: "country_multiselect_groups"
-};
-
 export const DATAPORTAL_UTILS_dataportal_sources_prod = {
   category: "category",
   body: "body",
@@ -323,13 +316,13 @@ export const OIL_EXTRAPOLATION_oil_prod_weo_extrapolated_prod = {
 };
 
 export const WORLD_ENERGY_HISTORY_electricity_capacity_prod = {
-  source: "source",
   group_type: "group_type",
   group_name: "group_name",
-  energy_family: "energy_family",
   year: "year",
-  power: "power",
+  energy_family: "energy_family",
   power_unit: "power_unit",
+  source: "source",
+  power: "power",
   __tableName: "WORLD_ENERGY_HISTORY_electricity_capacity_prod"
 };
 
@@ -367,4 +360,11 @@ export const WORLD_ENERGY_HISTORY_renewable_share_of_primary_energy_prod = {
   energy_unit: "energy_unit",
   source: "source",
   __tableName: "WORLD_ENERGY_HISTORY_renewable_share_of_primary_energy_prod"
+};
+
+export const country_multiselect_groups = {
+  group: "group",
+  country: "country",
+  country_only: "country_only",
+  __tableName: "country_multiselect_groups"
 };

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "apollo-server-express": "^2.10.1",
     "apollo-server-plugin-response-cache": "^0.3.11",
-    "better-sqlite3": "^9.6.0",
+    "better-sqlite3": "11.5",
     "body-parser": "^1.19.0",
     "csvtojson": "^2.0.10",
     "datasource-sql": "^1.1.1",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1450,10 +1450,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-9.6.0.tgz#b01e58ba7c48abcdc0383b8301206ee2ab81d271"
-  integrity sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==
+better-sqlite3@11.5:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.5.0.tgz#58faa51e02845a578dd154f0083487132ead0695"
+  integrity sha512-e/6eggfOutzoK0JWiU36jsisdWoHOfN9iWiW/SieKvb7SAa6aGNmBM/UKyp+/wWSXpLlWNN8tCPwoDNPhzUvuQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
Circle CI indique que les jobs de déploiement se déroulent avec succès. Cependant, les jobs de déploiements de l'API se terminent tous avec une erreur : #error "C++20 or later required." relatlive à la librairie `better-sqlite3` 

- upgrade better-sqlite3 to v 11.5 to fix the "C++20 or later required." error at API deployment