### PR TITLE
[DO NOT MERGE] fix(server): add command to seed DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
           name: Run Test
           command: yarn test
       - run:
-          name: Run typescript which is the same as running a build
-          command: yarn tsc
+          name: Build step
+          command: yarn build
 
   deploy-api:
     working_directory: ~/shiftdataportal
@@ -87,7 +87,7 @@ jobs:
           paths:
             - ./node_modules
       - run:
-          name: Run typescript which is the same as running a build
+          name: Build step
           command: yarn build
 
   deploy-front:


### PR DESCRIPTION
Le script `csv_to_sqlite.ts` n'est pas lancé dans la pipeline ce qui pourrait expliquer l'absence des nouvelles données dans la DB de production.